### PR TITLE
Cumulative Update

### DIFF
--- a/GameData/TokamakIndustries/changelog.txt
+++ b/GameData/TokamakIndustries/changelog.txt
@@ -1,3 +1,12 @@
+0.1++
+	Added life support for Orbital Orb, Munox Shuttle and Small Centrifuge.
+	Wrote descriptions and adjusted titles for Munox Shuttle and Munox Adapters.
+		Munox Shuttle will hold approximately 5x the amount of any LS 1.25m tank.
+	Added T.I. prefix to Dry Workshop and Munox parts to help with search function.
+	Moved Small Centrifuge to an appropriate place in Tech Tree.
+	Fixed USI patch:
+		Parts not showing in part selection.
+		Raised habitation values. -Thanks in part to forum user @Mihara.
 0.1.7
 	Removed extra files in the InflatoFlat
 

--- a/GameData/TokamakIndustries/lifesupport/Tokamak_KISM.cfg
+++ b/GameData/TokamakIndustries/lifesupport/Tokamak_KISM.cfg
@@ -54,13 +54,18 @@
 		desc = This place is big, robust, and smelly (...from the Kerosene traces). Why not put stuff in here so kerbals can happily get smelly? Oh, make sure there's more water and soap somewhere too.
 		bonus = exercise
 	}
-	//ContainerVolume = 36163
-	// MODULE:NEEDS[FeatureComfort]
-	// {
-		// name = Comfort
-		// desc = ...
-		// bonus = exercise
-	// }
+}
+
+@PART[centrifugeSmall]:NEEDS[Kerbalism&ProfileDefault]
+{
+	%tags = _kerbalism
+	@category = none
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		desc = It's spacious, it's beautiful, it's a PorkWork, and it goes round and round, simulating gravity. Isn't that great?!
+		bonus = firm-ground
+	}
 }
 
 @PART[TIinflato1,TIinflato2,TIinflatoFlat]:NEEDS[Kerbalism&ProfileDefault]
@@ -241,5 +246,139 @@
 	mtbf = 72576000 // 8y
 	extra_cost = 2.5
 	extra_mass = 0.1
+	}
+}
+
+@PART[TImunoxShuttle]:NEEDS[Kerbalism&ProfileDefault]:AFTER[Kerbalism]
+{
+	slotCount = 3 //placeholder variable, higher due to being a large command pod
+	%tags = _kerbalism
+	@category = none
+	ContainerVolume = 3100
+	
+	@MODULE[Habitat]
+	{
+		%volume = 25.727 //intended roughly two thirds of Kerbalism's computed volume
+	}
+	
+	@MODULE[Configure]:HAS[#title[Pod]]
+	{
+		@slots = 3
+		@SETUP[Waste?Processor]
+		{
+			@RESOURCE[Waste]
+			{
+				@maxAmount *= 5
+			}
+		}@SETUP[Water?Recycler]
+		{
+			@RESOURCE[WasteWater]
+			{
+				@maxAmount *= 5
+			}
+		}
+	}
+	
+	MODULE
+	{
+		name = Configure
+		title = Supply Container
+		slots = 1
+
+		SETUP
+		{
+			name = Supplies
+			desc = Store a balanced supply of <b>Food</b> and <b>Water</b>.
+
+			RESOURCE
+			{
+				name = Food
+				amount = 0.7224224
+				maxAmount = 0.7224224
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+
+			RESOURCE
+			{
+				name = Water
+				amount = 0.2775776
+				maxAmount = 0.2775776
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Food
+
+			RESOURCE
+			{
+				name = Food
+				amount = 1
+				maxAmount = 1
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		}
+		
+		SETUP
+		{
+			name = Water
+			
+			RESOURCE
+			{
+				name = Water
+				amount = 1
+				maxAmount = 1
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		}
+		
+		SETUP
+		{
+			name = Essentials
+			desc = Store a balanced supply of <b>Food, Water</b> and <b>Atmosphere</b>.
+			
+			RESOURCE
+			{
+				name = Food
+				amount = 0.3612112
+				maxAmount = 0.3612112
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+
+			RESOURCE
+			{
+				name = Water
+				amount = 0.1387888
+				maxAmount = 0.1387888
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+			
+			RESOURCE
+			{
+				name = Oxygen
+				amount = 404.61
+				maxAmount = 404.61
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+			
+			RESOURCE
+			{
+				name = Nitrogen
+				amount = 329.7
+				maxAmount = 329.7
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		
+		}
+
 	}
 }

--- a/GameData/TokamakIndustries/lifesupport/Tokamak_SNX.cfg
+++ b/GameData/TokamakIndustries/lifesupport/Tokamak_SNX.cfg
@@ -1,10 +1,13 @@
 @PART[TIinflato1]:NEEDS[Snacks]
 {
+	ExpectedCrew = 6 //placeholder variable
 	RESOURCE
 	{
 		name = Snacks
-		amount = 1200
-		maxAmount = 1200
+		amount = 200
+		maxAmount = 200
+		@amount *= #$../ExpectedCrew$
+		@maxAmount *= #$../ExpectedCrew$
 	}
 	
 	MODULE
@@ -27,14 +30,16 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio = 0.012 //0.002
+			Ratio = 0.002
+			@Ratio *= #$../../ExpectedCrew$
 			FlowMode = STAGE_PRIORITY_FLOW
   		}
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 180 //30
+			Ratio = 30
+			@Ratio *= #$../../ExpectedCrew$
 		}
 
 		//Snacks masses 0.001 metric tons per unit
@@ -42,7 +47,8 @@
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Snacks
-			Ratio = 0.06 //0.01
+			Ratio = 0.01
+			@Ratio *= #$../../ExpectedCrew$
 			DumpExcess = false
 			FlowMode = STAGE_PRIORITY_FLOW
 		}
@@ -51,15 +57,31 @@
 
 @PART[TIinflato2]:NEEDS[Snacks]
 {
+	ExpectedCrew = 6 //placeholder variable
 	RESOURCE
 	{
 		name = Snacks
-		amount = 1200
-		maxAmount = 1200
+		amount = 200
+		maxAmount = 200
+		@amount *= #$../ExpectedCrew$
+		@maxAmount *= #$../ExpectedCrew$
 	}
 }
 
-@PART[TIinflatoFlat]:NEEDS[Snacks]
+@PART[centrifugeSmall]:NEEDS[Snacks]
+{
+	ExpectedCrew = 2 //placeholder variable
+	RESOURCE
+	{
+		name = Snacks
+		amount = 200
+		maxAmount = 200
+		@amount *= #$../ExpectedCrew$
+		@maxAmount *= #$../ExpectedCrew$
+	}
+}
+
+@PART[TIinflatoFlat,TIorbitalorb]:NEEDS[Snacks]
 {
 	MODULE
 	{
@@ -95,7 +117,7 @@
 		SpecialistEfficiencyFactor = 0.1
 		ExperienceEffect = ScienceSkill
 		EfficiencyBonus = 1.0
-		RecyclerCapacity = 4
+		RecyclerCapacity = #$../CrewCapacity$
 	 
 		INPUT_RESOURCE
 		{
@@ -122,6 +144,67 @@
 
 @PART[TIdryworkshop]:NEEDS[Snacks]
 {
+	MODULE
+	{
+		name = SoilRecycler
+		ConverterName = Soil Recycler
+		StartActionName = Start Soil Recycler
+		StopActionName = Stop Soil Recycler
+		AutoShutdown = false
+		GeneratesHeat = false
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		UseSpecializationBonus = true
+		SpecialistEfficiencyFactor = 0.1
+		ExperienceEffect = ScienceSkill
+		EfficiencyBonus = 1.0
+		RecyclerCapacity = 8
+	 
+		INPUT_RESOURCE
+		{
+			ResourceName = Soil
+			Ratio = 0.000034723
+			FlowMode = ALL_VESSEL
+  		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 12
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Snacks
+			Ratio = 0.000034723
+			DumpExcess = false
+			FlowMode = ALL_VESSEL
+		}
+	}
+}
+
+@PART[TImunoxShuttle]:NEEDS[Snacks]
+{
+	MODULE
+	{
+		name = SnacksControlSource
+		debugMode = true
+	}
+
+	RESOURCE
+	{
+		name = Snacks
+		amount = 7500
+		maxAmount = 7500
+	}
+	
+	RESOURCE
+	{
+		name = Soil
+		amount = 0
+		maxAmount = 1500
+	}
+	
 	MODULE
 	{
 		name = SoilRecycler

--- a/GameData/TokamakIndustries/lifesupport/Tokamak_TAC.cfg
+++ b/GameData/TokamakIndustries/lifesupport/Tokamak_TAC.cfg
@@ -1,12 +1,4 @@
-@PART[TIinflato1]:NEEDS[TacLifeSupport]
-{
-	MODULE
-	{
-		name = LifeSupportModule
-	}
-}
-
-@PART[TIinflato2]:NEEDS[TacLifeSupport]
+@PART[TIinflato1,TIinflato2,centrifugeSmall]:NEEDS[TacLifeSupport]
 {
 	MODULE
 	{
@@ -17,10 +9,21 @@
 @PART[TIinflatoFlat]:NEEDS[TacLifeSupport]
 {
 	ExpectedCrew = 4 //placeholder variable
-    
+	
 	MODULE
 	{
 		name = LifeSupportModule
+	}
+	
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 100
+		maxAmount = 100
+		@amount *= #$../ExpectedCrew$
+		@amount += 150
+		@amount += #$maxAmount$
+		@maxAmount = #$amount$
 	}
 	
 	RESOURCE
@@ -28,60 +31,166 @@
         name = Food
         amount = 1.097
         maxAmount = 1.097
-        @amount *= #$/ExpectedCrew$
-        @maxAmount *= #$/ExpectedCrew$
+        @amount *= #$../ExpectedCrew$
+        @maxAmount *= #$../ExpectedCrew$
     }
     RESOURCE
     {
         name = Water
         amount = 0.725
         maxAmount = 0.725
-        @amount *= #$/ExpectedCrew$
-        @maxAmount *= #$/ExpectedCrew$
+        @amount *= #$../ExpectedCrew$
+        @maxAmount *= #$../ExpectedCrew$
     }
     RESOURCE
     {
         name = Oxygen
         amount = 111.038
         maxAmount = 111.038
-        @amount *= #$/ExpectedCrew$
-        @maxAmount *= #$/ExpectedCrew$
+        @amount *= #$../ExpectedCrew$
+        @maxAmount *= #$../ExpectedCrew$
     }
     RESOURCE
     {
         name = CarbonDioxide
         amount = 0
         maxAmount = 95.913
-        @maxAmount *= #$/ExpectedCrew$
+        @maxAmount *= #$../ExpectedCrew$
     }
     RESOURCE
     {
         name = Waste
         amount = 0
         maxAmount = 0.1
-        @maxAmount *= #$/ExpectedCrew$
+        @maxAmount *= #$../ExpectedCrew$
     }
     RESOURCE
     {
         name = WasteWater
         amount = 0
         maxAmount = 0.924
-        @maxAmount *= #$/ExpectedCrew$
+        @maxAmount *= #$../ExpectedCrew$
     }
-	
-	RESOURCE
+}
+
+@PART[TIorbitalorb]:NEEDS[TacLifeSupport]
+{
+	MODULE
 	{
-		name = ElectricCharge
-		amount = 100
-		maxAmount = 100
-		@amount *= #$/ExpectedCrew$
+		name = LifeSupportModule
+	}
+	
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 100
+		@maxAmount = 100
+		@amount *= #$../CrewCapacity$
 		@amount += 150
 		@amount += #$maxAmount$
 		@maxAmount = #$amount$
 	}
+	
+	RESOURCE
+    {
+        name = Food
+        amount = 1.097
+        maxAmount = 1.097
+        @amount *= #$../CrewCapacity$
+        @maxAmount *= #$../CrewCapacity$
+    }
+    RESOURCE
+    {
+        name = Water
+        amount = 0.725
+        maxAmount = 0.725
+        @amount *= #$../CrewCapacity$
+        @maxAmount *= #$../CrewCapacity$
+    }
+    RESOURCE
+    {
+        name = Oxygen
+        amount = 111.038
+        maxAmount = 111.038
+        @amount *= #$../CrewCapacity$
+        @maxAmount *= #$../CrewCapacity$
+    }
+    RESOURCE
+    {
+        name = CarbonDioxide
+        amount = 0
+        maxAmount = 95.913
+        @maxAmount *= #$../CrewCapacity$
+    }
+    RESOURCE
+    {
+        name = Waste
+        amount = 0
+        maxAmount = 0.1
+        @maxAmount *= #$../CrewCapacity$
+    }
+    RESOURCE
+    {
+        name = WasteWater
+        amount = 0
+        maxAmount = 0.924
+        @maxAmount *= #$../CrewCapacity$
+    }
 }
 
-// @PART[TIdryworkshop]:NEEDS[TacLifeSupport]
-// {
-	
-// }
+@PART[TImunoxShuttle]:NEEDS[TacLifeSupport]
+{
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 100
+		@maxAmount = 100
+		@amount *= #$../CrewCapacity$
+		@amount += 150
+		@amount += #$maxAmount$
+		@maxAmount = #$amount$
+	}
+	RESOURCE
+	{
+		name = Food
+		amount = 113.2
+		maxAmount = 113.2
+		@amount *= 5
+		@maxAmount *= 5
+	}
+	RESOURCE
+	{
+		name = Water
+		amount = 74.8
+		maxAmount = 74.8
+		@amount *= 5
+		@maxAmount *= 5
+	}
+	RESOURCE
+	{
+		name = Oxygen
+		amount = 11466.9
+		maxAmount = 11466.9
+		@amount *= 5
+		@maxAmount *= 5
+	}
+	RESOURCE
+	{
+		name = CarbonDioxide
+		amount = 0
+		maxAmount = 18800.1
+		@maxAmount *= 5
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		amount = 0
+		maxAmount = 180.9
+		@maxAmount *= 5
+	}
+	RESOURCE
+	{
+		name = Waste
+		amount = 0
+		maxAmount = 19.5
+		@maxAmount *= 5
+	}
+}

--- a/GameData/TokamakIndustries/lifesupport/Tokamak_USI.cfg
+++ b/GameData/TokamakIndustries/lifesupport/Tokamak_USI.cfg
@@ -1,16 +1,18 @@
 @PART[TIinflato1]:NEEDS[USILifeSupport]
 {
+	%tags = t.i. tokamak cck-lifesupport USI MKS LifeSupport habitat inflat
+	@category = none
 	MODULE
 	{
 		name = ModuleLogisticsConsumer
 	}	
 	
-	MODULE 
+	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 2
-		CrewCapacity = 6
-		BaseHabMultiplier = 1
+		BaseKerbalMonths = 44
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
 		ConverterName = Habitat
 		StartActionName = Start Habitat
 		StopActionName = Stop Habitat
@@ -45,6 +47,8 @@
 
 @PART[TIinflato2]:NEEDS[USILifeSupport]
 {
+	%tags = t.i. tokamak cck-lifesupport USI MKS habitat inflat assembl workshop
+	@category = none
 	MODULE
 	{
 		name = ModuleLogisticsConsumer
@@ -96,10 +100,7 @@
 
 @PART[TIinflatoFlat]:NEEDS[USILifeSupport]
 {
-	MODULE
-	{
-		name = ModuleLogisticsConsumer
-	}
+	%tags = t.i. tokamak inflat command pod
 	MODULE
 	{
 		name = ModuleHabitation
@@ -117,12 +118,23 @@
 
 @PART[TIdryworkshop]:NEEDS[USILifeSupport]
 {
-	MODULE
+	%tags = t.i. cck-lifesupport tokamak USI MKS assembl workshop
+	MODULE 
 	{
 		name = ModuleHabitation
-		KerbalMonths = 20
-		HabMultiplier = 0
+		BaseKerbalMonths = 45
+		CrewCapacity = 8
+		BaseHabMultiplier = 0
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.45
+		}
 	}
+	
 	MODULE
 	{
 		name = MKSModule
@@ -145,14 +157,10 @@
 	}
 }
 
-@PART[TIinflato1,TIinflato2,TIinflatoFlat,TIdryworkshop]:NEEDS[USILifeSupport]
-{
-	%tags = cck-lifesuport
-	@category = none
-}
-
 @PART[centrifugeSmall]:NEEDS[USILifeSupport]
 {
+	%tags = cck-lifesupport USI MKS LifeSupport habitat inflat
+	@category = none
 	MODULE
 	{
 		name = ModuleLifeSupport
@@ -179,3 +187,38 @@
 	}
 }
 
+@PART[TImunoxShuttle]:NEEDS[USILifeSupport]
+{
+	%tags = t.i. tokamak cck-lifesupport USI MKS LifeSupport habitat
+	@category = none
+	MODULE
+	{
+		name = ModuleLifeSupportRecycler
+		CrewCapacity = 8
+		RecyclePercent = .5
+		ConverterName = Life Support
+		tag = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 2
+		}
+	}
+	
+	RESOURCE
+	{
+		name = Supplies
+		amount = 2500
+		maxAmount = 2500
+	}
+	
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 500
+	}
+}

--- a/GameData/TokamakIndustries/parts/centrifugeSmall/centrifugeSmall.cfg
+++ b/GameData/TokamakIndustries/parts/centrifugeSmall/centrifugeSmall.cfg
@@ -10,7 +10,7 @@ PART
 	node_stack_top = 0.0, 1.375, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, -1.125, 0.0, 0.0, -1.0, 0.0, 1
 	
-	TechRequired = metaMaterials
+	TechRequired = advExploration
 	entryCost = 10000
 	cost = 10000
 	category = Utility

--- a/GameData/TokamakIndustries/parts/dryworkshop.cfg
+++ b/GameData/TokamakIndustries/parts/dryworkshop.cfg
@@ -42,9 +42,9 @@ PART
 	category = Utility
 	TechRequired = fuelSystems
 	subcategory = 0
-	title = Dry Workshop
+	title = T.I. Dry Workshop
 	manufacturer = Tokamak Industries - Reburished Parts Division
-	description = A hollowed out and re-fitted UDK brand fuel tank, designed to provide extra living space and allowing Kerbals to stay in space for much longer periods in... "comfort". The smell of refined kerosene is almost mostly gone.
+	description = A hollowed out and re-fitted UDK brand fuel tank, designed to provide extra living space and allowing Kerbals to stay in space for much longer periods in... "comfort". The smell of refined kerosene is almost...completely gone.
 
 	// --- Attachment Parameters ---
 	attachRules = 1,0,1,1,0
@@ -85,7 +85,6 @@ PART
 		evaOnlyStorage = True
 		storageRange = 2.0
 	}
-
 	
 	// --- End of Configuration ---
 }

--- a/GameData/TokamakIndustries/parts/inflato2/inflato2.cfg
+++ b/GameData/TokamakIndustries/parts/inflato2/inflato2.cfg
@@ -88,38 +88,5 @@ PART
 		CrewCapacity = 6
 	}
 	
-	// EPL support, copied from basic EPL workshop
-	MODULE:NEEDS[Launchpad]
-	{
-		name = ExWorkshop
-		ProductivityFactor = 5
-	}
-	
-	MODULE:NEEDS[Launchpad]
-	{
-		name = ExConverter
-		StartActionName = Start Part Production
-		StopActionName = Stop Part Production
-		INPUT_RESOURCE
-		{
-			ResourceName = Metal
-			Ratio = 0.0195
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 10
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = RocketParts
-			Ratio = 0.7
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = ScrapMetal
-			Ratio = 0.2995
-			DumpExcess = True
-		}
-	}
+	// --- End of Configuration ---
 }

--- a/GameData/TokamakIndustries/parts/munox.cfg
+++ b/GameData/TokamakIndustries/parts/munox.cfg
@@ -42,9 +42,9 @@ PART
 	cost = 10000
 	category = Utility
 	subcategory = 0
-	title = munox
+	title = T.I. Munox Service Shuttle
 	manufacturer = Tokamak Industries Reburished Parts Division
-	description = munox munox beepity boopity fountain pen
+	description = A couple of sleek hulls with mount points about them were found in the warehouses among the abandoned inflatables. Their intended purpose went on as lost files and a complete unknown but fortunately they were kept around. Recently, someone finally had a great idea, the idea to make service shuttles out of them, and have them carry a lot of food and kerbals at once.
 	bulkheadProfiles = size2
 
 	// --- Attachment Parameters ---
@@ -142,8 +142,6 @@ PART
 		amount = 100
 		maxAmount = 100
 	}
-
-	
 	
 	// --- End of Configuration ---
 }

--- a/GameData/TokamakIndustries/parts/munoxadapters.cfg
+++ b/GameData/TokamakIndustries/parts/munoxadapters.cfg
@@ -23,9 +23,9 @@ PART
 	
 	category = Structural
 	subcategory = 0
-	title = munox-adapter-perpendicular
-	manufacturer = Tokamaku
-	description =  munox-adapter-perpendicular
+	title = T.I. Munox Adapter, Perpendicular
+	manufacturer = Tokamak Industries Reburished Parts Division
+	description =  There will be cases where the Munox Shuttle's own tank space is not nearly enough for the next flight. So stack more LS tanks (or whatever else is necessary) in an interesting new way, with this quarter-turned mount.
 	attachRules = 1,1,1,1,1
 	
 	mass = 0.045
@@ -38,7 +38,7 @@ PART
 	breakingForce = 100
 	breakingTorque = 100
 
-	tags = connect frame scaffold structur strut truss radial
+	tags = connect frame scaffold structur strut truss radial mount
 }
 
 PART
@@ -66,9 +66,9 @@ PART
 	
 	category = Structural
 	subcategory = 0
-	title = munox-adapter-parallel
-	manufacturer = Tokamaku
-	description =  munox-adapter-parallel
+	title = T.I. Munox Adapter, Parallel
+	manufacturer = Tokamak Industries Reburished Parts Division
+	description = There will be cases where the Munox Shuttle's own tank space is not nearly enough for the next flight. So stack more LS tanks (or whatever else is necessary) the proper way, with this standardized mount.
 	attachRules = 1,1,1,1,1
 	
 	mass = 0.045
@@ -81,7 +81,7 @@ PART
 	breakingForce = 100
 	breakingTorque = 100
 
-	tags = connect frame scaffold structur strut truss radial
+	tags = tokamak connect frame scaffold structur strut truss radial mount
 }
 
 PART
@@ -110,9 +110,9 @@ PART
 	
 	category = Structural
 	subcategory = 0
-	title = munox-adapter-flat
-	manufacturer = Tokamaku
-	description =  munox-adapter-flat
+	title = T.I. Munox Adapter, Flat
+	manufacturer = Tokamak Industries Reburished Parts Division
+	description =  There will be cases where the Munox Shuttle's own tank space is not nearly enough for the next flight. So stack more LS tanks (or whatever else is necessary) proceeding away from the shuttle body, with this flat plate mount.
 	attachRules = 1,1,1,1,1
 	
 	mass = 0.045
@@ -125,5 +125,5 @@ PART
 	breakingForce = 100
 	breakingTorque = 100
 
-	tags = connect frame scaffold structur strut truss radial
+	tags = tokamak connect frame scaffold structur strut truss radial mount
 }

--- a/GameData/TokamakIndustries/parts/orbitalorb/part.cfg
+++ b/GameData/TokamakIndustries/parts/orbitalorb/part.cfg
@@ -1,103 +1,104 @@
 PART
 {
-name = TIorbitalorb
-module = Part
-author = Porkjet; internal seat and rcs tank models by Squad
+	name = TIorbitalorb
+	module = Part
+	author = Porkjet; internal seat and rcs tank models by Squad
 
 
 	{
 		model = TokamakIndustries/parts/orbitalorb/model000
 	}
 
-//mesh = model.mu
-scale = 1
-rescaleFactor = 1
+	//mesh = model.mu
+	scale = 1
+	rescaleFactor = 1
 
-node_stack_top = 0.0, 1.18, 0.0, 0.0, 1.0, 0.0
-node_stack_bottom = 0.0, -1.18, 0.0, 0.0, -1.0, 0.0
+	node_stack_top = 0.0, 1.18, 0.0, 0.0, 1.0, 0.0
+	node_stack_bottom = 0.0, -1.18, 0.0, 0.0, -1.0, 0.0
 
 
-TechRequired = specializedControl
-entryCost = 3000
-cost = 1500
-category = Pods
-subcategory = 0
-title = TMA-1 Orbital Orb
-manufacturer = Porkworks
-description = A spacious and lightweight crew module designed to accommodate kerbals in space for extended periods of time. As such, it lacks re-entry protection and structural reinforcements. Warranty void if leaving the launchpad.
-//description = A spacious and lightweight crew module designed to accommodate kerbals in space for extended periods of time. As such, it lacks re-entry protection and structural reinforcements. Warranty void if leaving the launchpad.
+	TechRequired = specializedControl
+	entryCost = 3000
+	cost = 1500
+	category = Pods
+	subcategory = 0
+	title = TMA-1 Orbital Orb
+	manufacturer = Porkworks
+	description = A spacious and lightweight crew module designed to accommodate kerbals in space for extended periods of time. As such, it lacks re-entry protection and structural reinforcements. Warranty void if leaving the launchpad.
+	//description = A spacious and lightweight crew module designed to accommodate kerbals in space for extended periods of time. As such, it lacks re-entry protection and structural reinforcements. Warranty void if leaving the launchpad.
 
-attachRules = 1,0,1,1,0
+	attachRules = 1,0,1,1,0
 
-mass = 2.3
-dragModelType = default
-maximum_drag = 0.2
-minimum_drag = 0.3
-angularDrag = 2
-crashTolerance = 12
-maxTemp = 2000
+	mass = 2.3
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.3
+	angularDrag = 2
+	crashTolerance = 12
+	maxTemp = 2000
 
-//stagingIcon = COMMAND_POD
-vesselType = Ship
+	//stagingIcon = COMMAND_POD
+	vesselType = Ship
 
-CrewCapacity = 2
+	CrewCapacity = 2
 
-INTERNAL
-{
-  name = TIorbitalOrbInternals
-}
-MODULE
-{
-	name = ModuleCommand
-	minimumCrew = 1
-}
-RESOURCE
-{
-	name = ElectricCharge
-	amount = 200
-	maxAmount = 200
-}
-RESOURCE
-{
-	name = MonoPropellant
-	amount = 50
-	maxAmount = 50
-}
-MODULE
-{
-	name = ModuleSAS
-}
-MODULE
-{
-name = ModuleAnimateGeneric
-animationName = light
-startEventGUIName = Lights on
-endEventGUIName = Lights off
-}
-MODULE
-{
-	name = ModuleScienceExperiment	
+	INTERNAL
+	{
+		name = TIorbitalOrbInternals
+	}
 	
-	experimentID = crewReport
+	MODULE
+	{
+		name = ModuleCommand
+		minimumCrew = 1
+	}
 	
-	experimentActionName = Crew Report
-	resetActionName = Discard Crew Report
-	reviewActionName = Review Report
+	MODULE
+	{
+		name = ModuleSAS
+	}
 	
-	useStaging = False	
-	useActionGroups = True
-	hideUIwhenUnavailable = True	
-	rerunnable = True
+	MODULE
+	{
+		name = ModuleAnimateGeneric
+		animationName = light
+		startEventGUIName = Lights on
+		endEventGUIName = Lights off
+	}
+	MODULE
+	{
+		name = ModuleScienceExperiment
+		experimentID = crewReport
+		experimentActionName = Crew Report
+		resetActionName = Discard Crew Report
+		reviewActionName = Review Report
+		useStaging = False	
+		useActionGroups = True
+		hideUIwhenUnavailable = True	
+		rerunnable = True
+		xmitDataScalar = 1.0
+	}
 	
-	xmitDataScalar = 1.0
-}
-MODULE
-{
-	name = ModuleScienceContainer
+	MODULE
+	{
+		name = ModuleScienceContainer
+		reviewActionName = Review Stored Data
+		storeActionName = Store Experiments
+		evaOnlyStorage = True
+		storageRange = 2.0
+	}
 	
-	reviewActionName = Review Stored Data
-	storeActionName = Store Experiments
-	evaOnlyStorage = True
-	storageRange = 2.0
-}
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 200
+		maxAmount = 200
+	}
+	
+	RESOURCE
+	{
+		name = MonoPropellant
+		amount = 50
+		maxAmount = 50
+	}
 }


### PR DESCRIPTION
* Added life support for Orbital Orb, Munox Shuttle and Small Centrifuge.
* Wrote descriptions and adjusted titles for Munox Shuttle and Munox Adapters.
  * Munox Shuttle will hold approximately 5x the amount of any life support 1.25m tank.
* Added T.I. prefix to Dry Workshop and Munox parts to help with search function.
* Removed redundant Extraplanetary Launchpad modules from Inflato Workshop.
* Moved Small Centrifuge to an appropriate place in Tech Tree (alongside stock Science Lab).
* Fixed USI patch:
  * Parts not showing in part selection.
  * Raised habitation values. -Thanks in part to forum user @Mihara.