### PR TITLE
Remove the RefreshContextWindows call.

### DIFF
--- a/Source/Habitat/DeployableHabitat.cs
+++ b/Source/Habitat/DeployableHabitat.cs
@@ -79,7 +79,6 @@ namespace Habitat
 				part.CrewCapacity = crewCapacityRetracted;
 			}
 			part.CheckTransferDialog();
-			MonoUtilities.RefreshContextWindows(part);
 		}
 
 		public void EnableModule ()


### PR DESCRIPTION
It caused problems in 1.3 and it turns out it isn't necessary in 1.3.1.